### PR TITLE
Fix `Array to string conversion` error

### DIFF
--- a/alphabetise.php
+++ b/alphabetise.php
@@ -19,7 +19,7 @@ function alphabetise($parent, $options=array()) {
 
   //Gets the input into a two dimensional array - uses '~' as separator;
   foreach ($parent as $item){
-    $temp = explode('~',$item->$options['key']() );
+    $temp = explode('~',$item->{$options['key']}() );
     $temp = $temp[0];
     $temp = strtolower($temp);
     $array[$temp][] = $item;


### PR DESCRIPTION
Without this fix, I was getting the following error:

```
Notice: Array to string conversion in /Users/paulrobertlloyd/Sites/bradshawsguide/site/plugins/alphabetise/alphabetise.php on line 21

Notice: Undefined property: Page::$Array in /Users/paulrobertlloyd/Sites/bradshawsguide/site/plugins/alphabetise/alphabetise.php on line 21

Fatal error: Method Kirby\Patterns\Pattern::__toString() must not throw an exception, caught Error: Function name must be a string in /Users/paulrobertlloyd/Sites/bradshawsguide/site/plugins/patterns/lib/helpers.php on line 0
```

My PHP knowledge is well, non-existent, but enough Googling led me to work out that this change will convert `$options['key']` into a useable string.
