### PR TITLE
Fixed web links

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,13 @@
   "version": "0.1.1",
   "type": "kirby-plugin",
   "description": "Alphabetise a Kirby CMS page array or tag array with key",
+  "homepage": "https://github.com/shoesforindustry/kirby-plugins-alphabetise",
   "license": "MIT",
   "authors": [
     {
       "name": "Russ Baldwin",
       "email": "russ@shoesforindustry.net",
-      "homepage": "https://shoesforindustry.net"
+      "homepage": "https://shoesforindustry.net/"
     }
   ]
 }

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ## What is it?
 
-The `alphabetise` plugin takes a given [Kirby CMS] (http://getkirby.com/) *page* array or *tag* array and returns an alphabetised or numbered array that you can then display or further process. It has been updated to work with Kirby CMS v3+.
+The `alphabetise` plugin takes a given [Kirby CMS](http://getkirby.com/) *page* array or *tag* array and returns an alphabetised or numbered array that you can then display or further process. It has been updated to work with Kirby CMS v3+.
 
 
 ## Installation


### PR DESCRIPTION
- Added root `homepage:` field to `composer.json` so that the plugin name is linked back to the repository when viewed in the Kirby 3 panel
- Added trailing slash to `authors:homepage:` field for consistency
- Fixed malformed link in `read.me`